### PR TITLE
fix: malformed policy document for sts assume role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "aws_backup_plan" "default" {
 }
 
 
-data "aws_iam_policy_document" "assume_role" {
+data "aws_iam_policy_document" "aws_backup_vault_policy" {
   count = local.iam_role_enabled ? 1 : 0
 
   statement {
@@ -95,7 +95,21 @@ resource "aws_backup_vault_policy" "example" {
   count = var.aws_backup_vault_policy_enabled ? 1 : 0
 
   backup_vault_name = join("", aws_backup_vault.default[*].name)
-  policy            = element(data.aws_iam_policy_document.assume_role[*].json, count.index)
+  policy            = element(data.aws_iam_policy_document.aws_backup_vault_policy[*].json, count.index)
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  count = local.iam_role_enabled && var.aws_backup_vault_policy_enabled == false ? 1 : 0
+
+  statement {
+    sid     = "AWSBackupAssumeRole"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+  }
 }
 
 resource "aws_iam_role" "default" {


### PR DESCRIPTION
## what
- Assume Role Policy statement

## why
Current assume_role_policy is throwing below error
> Error: creating IAM Role (aws-backup-ec2) : MalformedPolicyDocument: Has prohibited field Resource
status code: 400, request id: 12345678-abc-1234-1234-abcdegh with module.aws backup_ec2.aws_1am_role.default [0],
on .terraform/modules/aws backup ec2/main.tf line 101, in resource "aws iam role" "default":
101: resource "aws iam role" "default" {